### PR TITLE
Updating the GAE app to work out of the box

### DIFF
--- a/gae/app.yaml
+++ b/gae/app.yaml
@@ -14,3 +14,6 @@ handlers:
 libraries:
 - name: webapp2
   version: "2.5.2"
+- name: ssl
+  version: latest
+

--- a/gae/appengine_config.py
+++ b/gae/appengine_config.py
@@ -20,7 +20,8 @@ Duracron sample application config.
 This file is automatically imported by app engine
 """
 
-import os
-import sys
+from google.appengine.ext import vendor
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+# Add any libraries installed in the "lib" folder.
+vendor.add('lib')
+

--- a/gae/main.py
+++ b/gae/main.py
@@ -29,7 +29,7 @@ class MainHandler(webapp2.RequestHandler):
 class CronEventHandler(webapp2.RequestHandler):
     def get(self):
         topic_name = self.request.path.split(EVENTS_PREFIX)[-1]
-        publish_to_topic(topic_name)
+        publish_to_topic(topic_name, msg='test')
         self.response.status = 204
 
 

--- a/gae/pubsub_utils.py
+++ b/gae/pubsub_utils.py
@@ -18,7 +18,7 @@
 import base64
 from time import strftime
 import httplib2
-import oauth2client.appengine as gae_oauth2client
+import oauth2client.contrib.appengine as gae_oauth2client
 from apiclient import discovery
 from google.appengine.api import memcache
 from google.appengine.api import app_identity


### PR DESCRIPTION
I ran into the following issues when I tried to use the GAE part of this repo:
- Module layout for the AppEngine Python SDK has been refactored and module paths are different
- The SSL module is mandatory to get pub/sub working.
- Pub/Sub was returning "One or more messages in the publish request is empty. Each message must contain either non-empty data, or at least one attribute."

These changes make the GAE component work out of the box again albeit with a throw away "test" message.
