### PR TITLE
Fix warning due to missing `python-dev` package.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,9 +274,9 @@ directory.
         $ sudo apt-get update
 
 
-7. Install `pip` on the instance.
+7. Install `pip` and the Python development libraries on the instance.
 
-        $ sudo apt-get install -y python-pip
+        $ sudo apt-get install -y python-pip python-dev
 
 
 8. Install the [Python client library for accessing Google APIs](https://github.com/google/google-api-python-client) on the instance with Python Pip.


### PR DESCRIPTION
The pip install command outputs a warning. This is fixed by installing the `python-dev` package before running the pip install command.

```
Installing collected packages: google-api-python-client, pytz, httplib2, oauth2client, six, uritemplate, pyasn1, pyasn1-modules, rsa, simplejson
  Running setup.py install for httplib2

  Running setup.py install for oauth2client

    warning: no previously-included files matching '*' found under directory 'tests'
  Found existing installation: six 1.8.0
    Not uninstalling six at /usr/lib/python2.7/dist-packages, owned by OS
  Running setup.py install for uritemplate

  Running setup.py install for simplejson
    building 'simplejson._speedups' extension
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werro
r=format-security -fPIC -I/usr/include/python2.7 -c simplejson/_speedups.c -o build/temp.linux-x86_64-2.7/simplejson/_speedups.o
    simplejson/_speedups.c:2:20: fatal error: Python.h: No such file or directory
     #include "Python.h"
                        ^
    compilation terminated.
    ***************************************************************************
    WARNING: The C extension could not be compiled, speedups are not enabled.
    Failure information, if any, is above.
    I'm retrying the build without the C extension now.
    ***************************************************************************

    ***************************************************************************
    WARNING: The C extension could not be compiled, speedups are not enabled.
    Plain-Python installation succeeded.
    ***************************************************************************
```
