### PR TITLE
Fix GCE task runner import.

### DIFF
--- a/gce/cloud_handler.py
+++ b/gce/cloud_handler.py
@@ -23,7 +23,7 @@ from threading import Thread
 from apiclient import discovery
 
 import httplib2
-import oauth2client.gce as gce_oauth2client
+import oauth2client.contrib.gce as gce_oauth2client
 
 LOGGING_SCOPES = ["https://www.googleapis.com/auth/logging.admin",
                   "https://www.googleapis.com/auth/cloud-platform"]


### PR DESCRIPTION
The latest version of oauth2client moves the gce support to a contrib
directory.

Filed https://github.com/GoogleCloudPlatform/reliable-task-scheduling-compute-engine-sample/issues/7 to use requirements.txt to prevent broken samples in the future.
