### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ that you created in **Prerequisites**.
 
 4. Deploy the application to App Engine.
 
-        $ gcloud preview app deploy --version=1 gae/app.yaml \
+        $ gcloud app deploy --version=1 gae/app.yaml \
           gae/cron.yaml
 
 After you deploy the App Engine application it uses the App Engine Cron Service


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
